### PR TITLE
Add fko to the Basic Pronouns table

### DIFF
--- a/en/morphology.tex
+++ b/en/morphology.tex
@@ -111,6 +111,7 @@ Person      & Singular & Dual & Trial & Plural \\
 3rd animate & \N{po}  & \N{me\ACC{fo}} & \N{pxe\ACC{fo}}  & \N{ay\ACC{fo}, fo} \\
 3rd inanimate   & \N{\ACC{tsa}'u}, \N{tsaw} & \N{me\ACC{sa}'u} & \N{pxe\ACC{sa}'u} & \N{ay\ACC{sa}'u, sa'u} \\
 reflexive & \N{sno} & — & — & — \\
+indeterminate & \N{fko} & — & — & — \\
 \end{tabular}
 \end{center}
 


### PR DESCRIPTION
It makes little sense to me that sno is in the table, but fko is not. This could have been an oversight from when the paragraph about fko was originally added.